### PR TITLE
Add stage and prod app flavors to gradle.build

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -76,6 +76,19 @@ android {
             signingConfig signingConfigs.release
         }
     }
+    flavorDimensions "backend"
+
+    productFlavors {
+        prod{
+            dimension "backend"
+        }
+        stage{
+            dimension "backend"
+            applicationIdSuffix ".stage"
+            versionNameSuffix "-stage"
+        }
+    }
+
 }
 
 flutter {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <application
-        android:label="Tentura"
+        android:label="@string/app_name"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity
@@ -31,9 +31,9 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:host="tentura.intersubjective.space" />
-                <data android:scheme="http" android:host="tentura.intersubjective.space" />
-                <data android:scheme="https" android:host="tentura.intersubjective.space" />
+                <data android:host="@string/deep_link_hostname" />
+                <data android:scheme="http" android:host="@string/deep_link_hostname" />
+                <data android:scheme="https" android:host="@string/deep_link_hostname" />
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<resources>
+    <string name="app_name">Tentura</string>
+    <string name="deep_link_hostname">tentura.intersubjective.space</string>
+</resources>
+

--- a/android/app/src/stage/res/values/strings.xml
+++ b/android/app/src/stage/res/values/strings.xml
@@ -1,0 +1,5 @@
+<resources>
+    <string name="app_name">Tentura-stage</string>
+    <string name="deep_link_hostname">tentura-stage.intersubjective.space</string>
+</resources>
+


### PR DESCRIPTION
We can now build a separate flavor of the app ("stage") using a different app id and a different server and deep linking urls.