### PR TITLE
Fix graph tap explore vs rollback intent

### DIFF
--- a/packages/client/lib/features/graph/ui/bloc/graph_cubit.dart
+++ b/packages/client/lib/features/graph/ui/bloc/graph_cubit.dart
@@ -86,6 +86,9 @@ class GraphCubit extends Cubit<GraphState> {
        ) {
     _pinnedNodeIds.add(_egoNode.id);
     _focusPathIds.add(_egoNode.id);
+    if (!genealogyMode) {
+      _everFocusedIds.add(_egoNode.id);
+    }
     unawaited(_fetch());
   }
 
@@ -145,6 +148,10 @@ class GraphCubit extends Cubit<GraphState> {
   final _pinnedNodeIds = <String>{};
 
   final _focusPathIds = <String>[];
+
+  /// Nodes that have been focus at least once this session (plus seeded
+  /// genealogy parent-chain). Used to distinguish explore vs rollback taps.
+  final _everFocusedIds = <String>{};
 
   String _forwardsAuthorId = '';
 
@@ -210,9 +217,17 @@ class GraphCubit extends Cubit<GraphState> {
     unawaited(Future.value(graphController.jumpToNode(node)));
   }
 
-  /// True when a tap should run one [expandNode] to nudge further exploration
-  /// (hidden neighbours remain, or this node has never been fetched as focus).
-  bool canExpandNode(String id) {
+  /// True when [id] owns the active spotlight (including trust overview).
+  bool isCurrentFocus(String id) {
+    if (state.focus == id) {
+      return true;
+    }
+    return _isTrustGraph && state.focus.isEmpty && id == _focusRootId;
+  }
+
+  /// True when the current focus can page in another neighbourhood window.
+  /// Only meaningful for [isCurrentFocus] nodes and the Expand control.
+  bool canPageMore(String id) {
     if (forwardsGraphBeaconId != null) {
       return false;
     }
@@ -220,14 +235,19 @@ class GraphCubit extends Cubit<GraphState> {
     if (hidden > 0) {
       return true;
     }
-    if (genealogyMode) {
-      return false;
-    }
-    if (id == _focusRootId) {
+    if (genealogyMode || id == _focusRootId) {
       return false;
     }
     return !_fetchLimits.containsKey(id);
   }
+
+  /// Whether [id] has been focused before (rollback taps select only).
+  @visibleForTesting
+  bool hasEverFocused(String id) => _everFocusedIds.contains(id);
+
+  /// @deprecated Use [isCurrentFocus], [canPageMore], and [handleNodeTap].
+  @Deprecated('Use isCurrentFocus, canPageMore, and handleNodeTap')
+  bool canExpandNode(String id) => canPageMore(id);
 
   /// Highlights [node] on the graph and updates the exploration trail.
   /// Never pages neighbourhood — use [expandNode]. May request structural
@@ -239,6 +259,7 @@ class GraphCubit extends Cubit<GraphState> {
     if (state.focus == node.id) {
       return;
     }
+    _everFocusedIds.add(node.id);
     emit(state.copyWith(focus: node.id));
     _updateFocusPath(node.id);
     if (_usesFocusPathVisibility) {
@@ -252,14 +273,39 @@ class GraphCubit extends Cubit<GraphState> {
 
   /// Selects [node] when needed, then pages in the next neighbourhood window.
   Future<void> expandNode(NodeDetails node) async {
-    if (state.focus != node.id) {
+    final trustOverviewPaging =
+        _isTrustGraph &&
+        state.focus.isEmpty &&
+        node.id == _focusRootId;
+    if (!trustOverviewPaging && state.focus != node.id) {
       // Skip select-time ensure: [_fetch] closes over the staged neighbourhood
       // before the first paint of new nodes.
       selectNode(node, ensureStructuralEdges: false);
+    } else {
+      _everFocusedIds.add(node.id);
     }
     if (forwardsGraphBeaconId == null) {
       await _fetch();
     }
+  }
+
+  /// Routes a node tap by explore / rollback intent (trust + genealogy).
+  void handleNodeTap(NodeDetails node) {
+    if (forwardsGraphBeaconId != null) {
+      selectNode(node);
+      return;
+    }
+    if (isCurrentFocus(node.id)) {
+      if (canPageMore(node.id)) {
+        unawaited(expandNode(node));
+      }
+      return;
+    }
+    if (_everFocusedIds.contains(node.id)) {
+      selectNode(node);
+      return;
+    }
+    unawaited(expandNode(node));
   }
 
   /// Steps one hop back along the exploration trail. Does not page
@@ -417,6 +463,12 @@ class GraphCubit extends Cubit<GraphState> {
       ..add(rootId);
   }
 
+  void _seedGenealogyEverFocused() {
+    _everFocusedIds
+      ..addAll(_genealogyParentChainNodeIds)
+      ..add(_focusRootId);
+  }
+
   ///
   ///
   Future<void> setContext(String? context) {
@@ -437,6 +489,9 @@ class GraphCubit extends Cubit<GraphState> {
     _fetchLimits.clear();
     _addedEdgeEndpoints.clear();
     _allEdges.clear();
+    _everFocusedIds
+      ..clear()
+      ..add(_egoNode.id);
     _focusPathIds
       ..clear()
       ..add(_egoNode.id);
@@ -549,6 +604,7 @@ class GraphCubit extends Cubit<GraphState> {
           _genealogyParentChainNodeIds.addAll(
             graph.nodes.map((node) => node.nodeKey),
           );
+          _seedGenealogyEverFocused();
           _preloadGenealogyNodes(graph.nodes);
           await _fetchGenealogyChildCounts(
             source,

--- a/packages/client/lib/features/graph/ui/widget/graph_body.dart
+++ b/packages/client/lib/features/graph/ui/widget/graph_body.dart
@@ -80,11 +80,7 @@ class GraphBodyState extends State<GraphBody>
   void _toggleLegend() => setState(() => _legendExpanded = !_legendExpanded);
 
   void _onNodeTap(NodeDetails node) {
-    if (_graphCubit.canExpandNode(node.id)) {
-      unawaited(_graphCubit.expandNode(node));
-    } else {
-      _graphCubit.selectNode(node);
-    }
+    _graphCubit.handleNodeTap(node);
   }
 
   void _openNodeDetails(NodeDetails node) {
@@ -149,14 +145,16 @@ class GraphBodyState extends State<GraphBody>
                       }
                     }
                   }
+                  final focused = focusedNode;
                   return _GraphTopControls(
                     legendExpanded: _legendExpanded,
                     onToggleLegend: _toggleLegend,
-                    focusedNode: focusedNode,
+                    focusedNode: focused,
                     showExpand: _graphCubit.forwardsGraphBeaconId == null,
-                    onExpand: focusedNode == null
+                    onExpand: focused == null ||
+                            !_graphCubit.canPageMore(focused.id)
                         ? null
-                        : () => _graphCubit.expandNode(focusedNode!),
+                        : () => _graphCubit.expandNode(focused),
                     onOpenDetails: focusedNode == null
                         ? null
                         : () => _openNodeDetails(focusedNode!),

--- a/packages/client/lib/features/graph/ui/widget/graph_node_widget.dart
+++ b/packages/client/lib/features/graph/ui/widget/graph_node_widget.dart
@@ -93,7 +93,10 @@ class GraphNodeWidget extends StatelessWidget {
             child: BlocSelector<GraphCubit, GraphState, int?>(
               selector: (state) => state.hiddenNeighborCounts[nodeDetails.id],
               builder: (context, count) {
-                if (count == null || count <= 0) {
+                final cubit = context.read<GraphCubit>();
+                if (!cubit.isCurrentFocus(nodeDetails.id) ||
+                    count == null ||
+                    count <= 0) {
                   return const SizedBox.shrink();
                 }
                 return TenturaCountBadge(

--- a/packages/client/pubspec.yaml
+++ b/packages/client/pubspec.yaml
@@ -2,11 +2,7 @@ name: tentura
 description: 'Social network for communities'
 publish_to: 'none'
 
-<<<<<<< Updated upstream
-version: 5.6.17
-=======
-version: 5.6.19
->>>>>>> Stashed changes
+version: 5.6.18
 
 environment:
   sdk: ^3.12.0

--- a/packages/client/pubspec.yaml
+++ b/packages/client/pubspec.yaml
@@ -2,7 +2,11 @@ name: tentura
 description: 'Social network for communities'
 publish_to: 'none'
 
+<<<<<<< Updated upstream
 version: 5.6.17
+=======
+version: 5.6.19
+>>>>>>> Stashed changes
 
 environment:
   sdk: ^3.12.0

--- a/packages/client/test/features/graph/graph_body_genealogy_test.dart
+++ b/packages/client/test/features/graph/graph_body_genealogy_test.dart
@@ -68,6 +68,18 @@ class _StubGraphCubit extends Cubit<GraphState> implements GraphCubit {
   bool canExpandNode(String id) => false;
 
   @override
+  bool canPageMore(String id) => false;
+
+  @override
+  bool isCurrentFocus(String id) => false;
+
+  @override
+  void handleNodeTap(NodeDetails node) {}
+
+  @override
+  bool hasEverFocused(String id) => false;
+
+  @override
   dynamic noSuchMethod(Invocation invocation) =>
       throw UnimplementedError('${invocation.memberName}');
 }

--- a/packages/client/test/features/graph/graph_body_navigation_controls_test.dart
+++ b/packages/client/test/features/graph/graph_body_navigation_controls_test.dart
@@ -24,6 +24,7 @@ import '../../ui/effect/fake_ui_effect_port.dart';
 
 class _WidgetTestGraphSource extends GraphSourceRepository {
   final pages = <String?, Set<EdgeDirected>>{};
+  int ubFetches = 0;
 
   @override
   Future<Set<EdgeDirected>> fetch({
@@ -34,7 +35,15 @@ class _WidgetTestGraphSource extends GraphSourceRepository {
     int limit = 5,
     String? viewerUserId,
     Set<String> excludeNeighborIds = const {},
-  }) async => pages[focus] ?? const {};
+  }) async {
+    if (focus == 'Ub') {
+      ubFetches += 1;
+      if (ubFetches == 1) {
+        return {_e('Ub', 'Ue', srcTotal: 3)};
+      }
+    }
+    return pages[focus] ?? const {};
+  }
 }
 
 const _edgeColors = GraphEdgeColors(
@@ -70,7 +79,11 @@ class _FakeProfileCubit extends Mock implements ProfileCubit {
   Stream<ProfileState> get stream => Stream<ProfileState>.value(state);
 }
 
-EdgeDirected _e(String src, String dst) => (
+EdgeDirected _e(
+  String src,
+  String dst, {
+  int? srcTotal,
+}) => (
   src: src,
   dst: dst,
   weight: 1.0,
@@ -78,7 +91,7 @@ EdgeDirected _e(String src, String dst) => (
     user: Profile(id: dst, displayName: dst),
   ),
   branch: null,
-  srcTotalNeighborCount: null,
+  srcTotalNeighborCount: srcTotal,
   dstTotalNeighborCount: null,
 );
 
@@ -156,7 +169,6 @@ void main() {
       final source = _WidgetTestGraphSource()
         ..pages.addAll({
           null: {_e('Ume', 'Ub')},
-          'Ub': {_e('Ub', 'Ue')},
         });
       await _pumpGraphBody(
         tester,

--- a/packages/client/test/features/graph/graph_body_select_expand_test.dart
+++ b/packages/client/test/features/graph/graph_body_select_expand_test.dart
@@ -25,6 +25,7 @@ import '../../ui/effect/fake_ui_effect_port.dart';
 class _WidgetTestGraphSource extends GraphSourceRepository {
   final pages = <String?, Set<EdgeDirected>>{};
   int calls = 0;
+  int ubFetches = 0;
 
   @override
   Future<Set<EdgeDirected>> fetch({
@@ -37,6 +38,18 @@ class _WidgetTestGraphSource extends GraphSourceRepository {
     Set<String> excludeNeighborIds = const {},
   }) async {
     calls += 1;
+    if (focus == 'Ub') {
+      ubFetches += 1;
+      if (ubFetches == 1) {
+        return {
+          _e('Ub', 'Ue', srcTotal: 3),
+        };
+      }
+      return {
+        _e('Ub', 'Ue', srcTotal: 3),
+        _e('Ub', 'Uf', srcTotal: 3),
+      };
+    }
     return pages[focus] ?? const {};
   }
 }
@@ -74,7 +87,12 @@ class _FakeProfileCubit extends Mock implements ProfileCubit {
   Stream<ProfileState> get stream => Stream<ProfileState>.value(state);
 }
 
-EdgeDirected _e(String src, String dst) => (
+EdgeDirected _e(
+  String src,
+  String dst, {
+  int? srcTotal,
+  int? dstTotal,
+}) => (
   src: src,
   dst: dst,
   weight: 1.0,
@@ -82,8 +100,8 @@ EdgeDirected _e(String src, String dst) => (
     user: Profile(id: dst, displayName: dst),
   ),
   branch: null,
-  srcTotalNeighborCount: null,
-  dstTotalNeighborCount: null,
+  srcTotalNeighborCount: srcTotal,
+  dstTotalNeighborCount: dstTotal,
 );
 
 Future<void> _settleGraph(WidgetTester tester) async {
@@ -184,7 +202,6 @@ void main() {
     final source = _WidgetTestGraphSource()
       ..pages.addAll({
         null: {_e('Ume', 'Ub')},
-        'Ub': {_e('Ub', 'Ue')},
       });
     final cubit = await _pumpGraphBody(tester, source: source);
     expect(source.calls, 1);
@@ -192,14 +209,15 @@ void main() {
     await tester.tap(find.byType(GraphNodeWidget).at(1));
     await _settleGraph(tester);
     expect(source.calls, 2);
-    expect(
-      cubit.graphController.edges.map((e) => e.destination.id),
-      contains('Ue'),
-    );
+    expect(cubit.state.hiddenNeighborCounts['Ub'], greaterThan(0));
 
     await tester.tap(find.text('Expand'));
     await _settleGraph(tester);
 
     expect(source.calls, 3);
+    expect(
+      cubit.graphController.edges.map((e) => e.destination.id),
+      contains('Uf'),
+    );
   });
 }

--- a/packages/client/test/features/graph/graph_cubit_genealogy_test.dart
+++ b/packages/client/test/features/graph/graph_cubit_genealogy_test.dart
@@ -679,6 +679,65 @@ void main() {
     },
   );
 
+  test(
+    'genealogy tap on parent chain after sibling spotlight selects only',
+    () async {
+      final rootAt = DateTime.utc(2026);
+      final child1At = DateTime.utc(2026, 2);
+      final child2At = DateTime.utc(2026, 3);
+      final repo = _FakeInviteGenealogyRepository()
+        ..bootstrapGraph = InviteGenealogyGraph(
+          viewerNodeKey: 'Groot',
+          nodes: [_node('Groot', _viewer, rootAt)],
+          edges: [],
+        )
+        ..childrenPages.addAll([
+          (
+            nodes: [
+              _node('Groot', _viewer, rootAt),
+              _node('Gchild1', _friend, child1At),
+            ],
+            edges: [_edge('Groot', 'Gchild1', rootAt, child1At)],
+          ),
+          (
+            nodes: [
+              _node('Groot', _viewer, rootAt),
+              _node('Gchild2', _target, child2At),
+            ],
+            edges: [_edge('Groot', 'Gchild2', rootAt, child2At)],
+          ),
+        ]);
+      final cubit = _cubit(repo: repo);
+
+      await _settleCubitFetch();
+      final root = cubit.graphController.nodes.singleWhere(
+        (node) => node.id == 'Groot',
+      );
+
+      cubit.expandNode(root);
+      await _settleCubitFetch();
+      cubit.expandNode(root);
+      await _settleCubitFetch();
+
+      final child1 = cubit.graphController.nodes.singleWhere(
+        (node) => node.id == 'Gchild1',
+      );
+      cubit.expandNode(child1);
+      await _settleCubitFetch();
+
+      final childrenCallsBefore = repo.childrenCalls.length;
+      expect(cubit.hasEverFocused('Groot'), isTrue);
+
+      cubit.handleNodeTap(root);
+      await _settleCubitFetch();
+
+      expect(repo.childrenCalls.length, childrenCallsBefore);
+      expect(cubit.state.focus, 'Groot');
+
+      await cubit.close();
+    },
+  );
+
   test('genealogy mode ignores context and positive-only controls', () async {
     final repo = _FakeInviteGenealogyRepository()
       ..bootstrapGraph = InviteGenealogyGraph(

--- a/packages/client/test/features/graph/graph_focus_path_visibility_test.dart
+++ b/packages/client/test/features/graph/graph_focus_path_visibility_test.dart
@@ -207,7 +207,7 @@ NodeDetails _liveNode(GraphCubit cubit, String id) =>
     cubit.graphController.nodes.singleWhere((n) => n.id == id);
 
 void main() {
-  test('canExpandNode is true for unseen neighbours and false for ego', () async {
+  test('canPageMore reflects paging state for the current focus', () async {
     final source = _FakeGraphSource()
       ..pages.addAll({
         null: {_e('Ume', 'Ub', dstTotal: 3)},
@@ -216,17 +216,102 @@ void main() {
     final cubit = _cubit(source);
     await _settle();
 
-    expect(cubit.canExpandNode('Ume'), isFalse);
-    expect(cubit.canExpandNode('Ub'), isTrue);
+    expect(cubit.isCurrentFocus('Ume'), isTrue);
+    expect(cubit.canPageMore('Ume'), isFalse);
 
-    cubit.expandNode(_liveNode(cubit, 'Ub'));
+    cubit.handleNodeTap(_liveNode(cubit, 'Ub'));
     await _settle();
 
-    // All declared neighbours are now visible — further taps only select.
-    expect(cubit.canExpandNode('Ub'), isFalse);
+    expect(cubit.isCurrentFocus('Ub'), isTrue);
+    expect(cubit.canPageMore('Ub'), isFalse);
 
     await cubit.close();
   });
+
+  test(
+    'rollback tap on ancestor with hidden badge does not fetch',
+    () async {
+      final source = _FakeGraphSource()
+        ..pages.addAll({
+          null: {_e('Ume', 'Ub'), _e('Ume', 'Uc')},
+          'Ub': {_e('Ub', 'Ue')},
+        });
+      final cubit = _cubit(source);
+      await _settle();
+      expect(source.calls, 1);
+
+      cubit.expandNode(_liveNode(cubit, 'Ub'));
+      await _settle();
+      cubit.expandNode(_liveNode(cubit, 'Ue'));
+      await _settle();
+      expect(source.calls, 3);
+      expect(cubit.hasEverFocused('Ume'), isTrue);
+
+      cubit.handleNodeTap(_liveNode(cubit, 'Ume'));
+      await _settle();
+
+      expect(source.calls, 3);
+      expect(cubit.state.focus, 'Ume');
+      expect(_nodeIds(cubit), containsAll(['Ume', 'Ub', 'Uc']));
+      await cubit.close();
+    },
+  );
+
+  test(
+    'resetToEgo keeps everFocused so rollback taps do not refetch',
+    () async {
+      final source = _FakeGraphSource()
+        ..pages.addAll({
+          null: {_e('Ume', 'Ub')},
+          'Ub': {_e('Ub', 'Ue')},
+        });
+      final cubit = _cubit(source);
+      await _settle();
+
+      cubit.expandNode(_liveNode(cubit, 'Ub'));
+      await _settle();
+      final callsAfterExplore = source.calls;
+
+      cubit.resetToEgo();
+      await _settle();
+      expect(cubit.state.focus, isEmpty);
+
+      cubit.handleNodeTap(_liveNode(cubit, 'Ub'));
+      await _settle();
+
+      expect(source.calls, callsAfterExplore);
+      expect(cubit.state.focus, 'Ub');
+      await cubit.close();
+    },
+  );
+
+  test(
+    'setContext clears everFocused so a cached node can explore again',
+    () async {
+      final source = _FakeGraphSource()
+        ..pages.addAll({
+          null: {_e('Ume', 'Ub')},
+          'Ub': {_e('Ub', 'Ue')},
+        });
+      final cubit = _cubit(source);
+      await _settle();
+
+      cubit.expandNode(_liveNode(cubit, 'Ub'));
+      await _settle();
+      cubit.resetToEgo();
+      await _settle();
+
+      await cubit.setContext('work');
+      await _settle();
+      expect(source.calls, 3);
+
+      cubit.handleNodeTap(_liveNode(cubit, 'Ub'));
+      await _settle();
+
+      expect(source.calls, 4);
+      await cubit.close();
+    },
+  );
 
   test(
     'new focus neighbours immediately show cached chords to already-visible '

--- a/packages/client/test/features/graph/graph_legend_test.dart
+++ b/packages/client/test/features/graph/graph_legend_test.dart
@@ -80,6 +80,18 @@ class _StubGraphCubit extends Cubit<GraphState> implements GraphCubit {
   bool canExpandNode(String id) => false;
 
   @override
+  bool canPageMore(String id) => false;
+
+  @override
+  bool isCurrentFocus(String id) => false;
+
+  @override
+  void handleNodeTap(NodeDetails node) {}
+
+  @override
+  bool hasEverFocused(String id) => false;
+
+  @override
   dynamic noSuchMethod(Invocation invocation) =>
       throw UnimplementedError('${invocation.memberName}');
 }

--- a/packages/client/test/features/graph/graph_node_widget_genealogy_test.dart
+++ b/packages/client/test/features/graph/graph_node_widget_genealogy_test.dart
@@ -21,6 +21,20 @@ class _BadgeTestGraphCubit extends Cubit<GraphState> implements GraphCubit {
     emit(state.copyWith(hiddenNeighborCounts: counts));
   }
 
+  void setFocusId(String focus) {
+    emit(state.copyWith(focus: focus));
+  }
+
+  @override
+  String get originNodeId => 'Gviewer';
+
+  @override
+  bool isCurrentFocus(String id) =>
+      state.focus == id || (state.focus.isEmpty && id == 'Gviewer');
+
+  @override
+  bool canPageMore(String id) => false;
+
   @override
   dynamic noSuchMethod(Invocation invocation) =>
       throw UnimplementedError('${invocation.memberName}');
@@ -112,6 +126,7 @@ void main() {
         nodeDetails: GenealogyUserNode(nodeKey: 'Gviewer', user: _viewer),
       ),
     );
+    cubit.setFocusId('Gviewer');
 
     expect(find.byType(TenturaCountBadge), findsNothing);
 
@@ -157,6 +172,7 @@ void main() {
           nodeDetails: GenealogyUserNode(nodeKey: 'Gviewer', user: _viewer),
         ),
       );
+      cubit.setFocusId('Gviewer');
 
       final avatarElement = tester.element(find.byType(TenturaAvatar));
 


### PR DESCRIPTION
## Summary
- Route node taps by `everFocusedIds` and current focus instead of `hiddenNeighborCounts`, so rollback taps on ancestors/ego no longer trigger spurious neighbourhood fetches.
- Trust overview keeps paging from origin without collapsing `focus==''`; genealogy seeds parent-chain nodes as visited on bootstrap.
- Hidden-neighbour badges and the Expand button only afford paging on the current focus.

## Test plan
- [x] `flutter test` on graph focus-path, genealogy, and select/expand widget tests
- [ ] Manual: walk trust chain A→B→E, tap ego — path collapses, no new nodes load
- [ ] Manual: genealogy expand child branch, tap parent — siblings reappear without children fetch

Made with [Cursor](https://cursor.com)