### PR TITLE
Fix intermittent contact rename failure in My People (#98)

### DIFF
--- a/packages/client/lib/features/contacts/domain/use_case/contacts_case.dart
+++ b/packages/client/lib/features/contacts/domain/use_case/contacts_case.dart
@@ -54,6 +54,10 @@ final class ContactsCase extends UseCaseBase {
 
   String _accountId = '';
 
+  /// Bumped on every local rename/reset so an in-flight server refresh cannot
+  /// overwrite a just-saved subjective profile name with stale data.
+  int _localWriteSeq = 0;
+
   /// Emits whenever any contact name changes (rename, reset, sync, switch).
   Stream<void> get changes => _store.changes;
 
@@ -70,6 +74,7 @@ final class ContactsCase extends UseCaseBase {
 
   Future<void> _onAccountChanged(String accountId) async {
     _accountId = accountId;
+    _localWriteSeq = 0;
     _activeRefresh = null;
     _refreshPending = false;
     if (accountId.isEmpty) {
@@ -119,11 +124,14 @@ final class ContactsCase extends UseCaseBase {
 
   Future<void> _refreshOnce(String accountId) async {
     if (_disposed || accountId.isEmpty) return;
+    final writeSeqAtStart = _localWriteSeq;
     try {
       final names = await _repository.fetchMine();
       if (_disposed || accountId != _accountId) return;
+      if (writeSeqAtStart != _localWriteSeq) return;
       await _repository.replaceCache(accountId: accountId, names: names);
       if (_disposed || accountId != _accountId) return;
+      if (writeSeqAtStart != _localWriteSeq) return;
       _store.replaceAll(names);
     } catch (e) {
       if (!_disposed && accountId == _accountId) {
@@ -138,22 +146,34 @@ final class ContactsCase extends UseCaseBase {
     required String contactName,
   }) async {
     final name = contactName.trim();
-    await _repository.setContact(subjectId: subjectId, contactName: name);
-    await _repository.putCached(
-      accountId: _accountId,
-      subjectId: subjectId,
-      contactName: name,
-    );
-    _store.set(subjectId, name);
+    _localWriteSeq++;
+    try {
+      await _repository.setContact(subjectId: subjectId, contactName: name);
+      await _repository.putCached(
+        accountId: _accountId,
+        subjectId: subjectId,
+        contactName: name,
+      );
+      _store.set(subjectId, name);
+    } catch (e) {
+      _localWriteSeq--;
+      rethrow;
+    }
   }
 
   /// Removes the contact entry — the subject's self-chosen name shows again.
   Future<void> reset({required String subjectId}) async {
-    await _repository.deleteContact(subjectId: subjectId);
-    await _repository.removeCached(
-      accountId: _accountId,
-      subjectId: subjectId,
-    );
-    _store.remove(subjectId);
+    _localWriteSeq++;
+    try {
+      await _repository.deleteContact(subjectId: subjectId);
+      await _repository.removeCached(
+        accountId: _accountId,
+        subjectId: subjectId,
+      );
+      _store.remove(subjectId);
+    } catch (e) {
+      _localWriteSeq--;
+      rethrow;
+    }
   }
 }

--- a/packages/client/lib/features/profile_view/ui/dialog/rename_contact_dialog.dart
+++ b/packages/client/lib/features/profile_view/ui/dialog/rename_contact_dialog.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 
+import 'package:tentura_root/domain/entity/localizable.dart';
+
 import 'package:tentura/consts.dart';
 import 'package:tentura/domain/entity/profile.dart';
 import 'package:tentura/ui/l10n/l10n.dart';
@@ -55,7 +57,13 @@ class _RenameContactDialogState extends State<RenameContactDialog>
     } catch (e) {
       if (mounted) {
         setState(() => _busy = false);
-        showSnackBar(context, text: e.toString(), isError: true, error: e);
+        final localeName = L10n.of(context)?.localeName;
+        showSnackBar(
+          context,
+          text: e is Localizable ? e.toL10n(localeName) : e.toString(),
+          isError: true,
+          error: e,
+        );
       }
     }
   }

--- a/packages/client/pubspec.yaml
+++ b/packages/client/pubspec.yaml
@@ -2,7 +2,7 @@ name: tentura
 description: 'Social network for communities'
 publish_to: 'none'
 
-version: 5.12.0
+version: 5.12.1
 
 environment:
   sdk: ^3.12.0

--- a/packages/client/test/features/contacts/contacts_case_test.dart
+++ b/packages/client/test/features/contacts/contacts_case_test.dart
@@ -292,6 +292,62 @@ void main() {
       expect(repository.fetchMineCalls, callsBefore + 1);
       expect(store.all, {'u4': 'Once'});
     });
+
+    test(
+      'rename survives stale refresh after invite acceptance sync',
+      () async {
+        repository.cachedByAccount['acc-1'] = {
+          'u-new-friend': 'Invite Addressee',
+        };
+        repository.fetchMineResult = {
+          'u-new-friend': 'Invite Addressee',
+        };
+
+        await switchAccount('acc-1');
+        expect(case_.nameOf('u-new-friend'), 'Invite Addressee');
+
+        final staleFetch = Completer<void>();
+        repository.fetchMineHandler = () async {
+          await staleFetch.future;
+          return {'u-new-friend': 'Invite Addressee'};
+        };
+
+        final refreshFuture = case_.refresh();
+        await case_.rename(
+          subjectId: 'u-new-friend',
+          contactName: 'My Local Name',
+        );
+
+        expect(case_.nameOf('u-new-friend'), 'My Local Name');
+
+        staleFetch.complete();
+        await refreshFuture;
+        await Future<void>.delayed(Duration.zero);
+
+        expect(case_.nameOf('u-new-friend'), 'My Local Name');
+      },
+    );
+
+    test('failed rename rolls back write guard so refresh can apply', () async {
+      await switchAccount('acc-1');
+      store.set('u1', 'Before');
+      repository.setContactError = StateError('network');
+
+      await expectLater(
+        case_.rename(subjectId: 'u1', contactName: 'After'),
+        throwsA(isA<StateError>()),
+      );
+      expect(case_.nameOf('u1'), 'Before');
+
+      repository.setContactError = null;
+      repository.fetchMineResult = {'u1': 'Server'};
+      final syncReady = repository.nextSync();
+      await case_.refresh();
+      await syncReady;
+      await Future<void>.delayed(Duration.zero);
+
+      expect(case_.nameOf('u1'), 'Server');
+    });
   });
 }
 
@@ -336,6 +392,7 @@ class FakeContactsRepository implements ContactsRepository {
   Map<String, Map<String, String>> cachedByAccount = {};
   Map<String, String> fetchMineResult = {};
   Object? fetchMineError;
+  Object? setContactError;
   Future<Map<String, String>> Function()? fetchMineHandler;
   int fetchMineCalls = 0;
 
@@ -406,6 +463,9 @@ class FakeContactsRepository implements ContactsRepository {
     required String subjectId,
     required String contactName,
   }) async {
+    if (setContactError != null) {
+      throw setContactError!;
+    }
     lastSetContact = (subjectId: subjectId, contactName: contactName);
   }
 

--- a/packages/client/web/index.html
+++ b/packages/client/web/index.html
@@ -129,7 +129,7 @@
     }
   </script>
 
-  <script src="flutter_bootstrap.js?v=5.12.0" async=""></script>
+  <script src="flutter_bootstrap.js?v=5.12.1" async=""></script>
 
   <script>
     if ('serviceWorker' in navigator) {

--- a/packages/client/web/manifest.json
+++ b/packages/client/web/manifest.json
@@ -9,7 +9,7 @@
   "orientation": "portrait-primary",
   "prefer_related_applications": true,
   "manifest_version": 3,
-  "version": "2.4.0",
+  "version": "5.12.1",
   "icons": [
     {
       "src": "icons/Icon-192.png",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #98 (parent #96).

Contact rename in My People could fail intermittently or appear to fail because:

1. **Stale refresh race** — An in-flight `myContacts` fetch (often triggered by invite acceptance or realtime invalidation) could complete after a successful rename and call `ContactNameStore.replaceAll()` with older data, reverting the new local alias.
2. **Bad error surfacing** — `RenameContactDialog` showed `e.toString()` on failures, which renders `RemoteApiException` as `Instance of 'RemoteApiException'` instead of the server message.

**Changes:**
- `ContactsCase` tracks a local write sequence; refreshes that started before a rename/reset no longer overwrite the store or Drift cache when they complete.
- Failed rename/reset rolls back the write guard so a subsequent refresh can still apply.
- `RenameContactDialog` uses `Localizable.toL10n()` for error snackbars (same pattern as `UiEffectDispatcher`).
- Regression tests cover rename during a stale post-invite refresh and failed-rename rollback.
- Client patch bump to 5.11.1.

## Test plan

- [x] `cd packages/client && flutter test test/features/contacts/contacts_case_test.dart --dart-define=ENV=test` — all 16 tests pass
- [x] `./scripts/check-custom-lints.sh packages/client` — no new issues in changed paths
- [ ] Full client suite in CI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1bd15312-285c-4ff5-aa8a-6e9c67bc52e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1bd15312-285c-4ff5-aa8a-6e9c67bc52e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

