### PR TITLE
fix(client): fold thread chrome into the top bar

### DIFF
--- a/packages/client/lib/features/beacon_threads/ui/screen/thread_detail_screen.dart
+++ b/packages/client/lib/features/beacon_threads/ui/screen/thread_detail_screen.dart
@@ -18,6 +18,7 @@ import 'package:tentura/features/beacon_threads/ui/widget/thread_detail.dart';
 import 'package:tentura/features/beacon_view/ui/bloc/beacon_view_cubit.dart';
 import 'package:tentura/features/beacon_view/ui/widget/closed_request_banner.dart';
 import 'package:tentura/features/coordination_item/ui/bloc/item_actions_cubit.dart';
+import 'package:tentura/features/coordination_item/ui/bloc/item_actions_state.dart';
 import 'package:tentura/ui/bloc/state_base.dart';
 import 'package:tentura/ui/l10n/l10n.dart';
 
@@ -178,9 +179,7 @@ class _ThreadDetailScreenState extends State<ThreadDetailScreen> {
             final beaconState = context.watch<BeaconViewCubit>().state;
             final beacon = beaconState.beacon;
             final titleFallback = thread.isGeneral
-                ? (beacon.title.isEmpty
-                      ? l10n.beaconViewTitle
-                      : beacon.title)
+                ? threadGeneralAppBarTitle(l10n, beacon)
                 : threadTitleFallback(l10n, thread);
 
             final detail = ThreadDetail(
@@ -208,13 +207,26 @@ class _ThreadDetailScreenState extends State<ThreadDetailScreen> {
                 leading: BackButton(
                   onPressed: () => unawaited(_closeThenPop()),
                 ),
-                title: item == null
+                title: thread.isGeneral
+                    ? ThreadDetailGeneralTitle(
+                        title: titleFallback,
+                        beacon: beacon,
+                        involvedProfiles: beaconState.activeHelpOfferUsers,
+                        currentUserId: beaconState.myProfile.id,
+                      )
+                    : item == null
                     ? Text(
                         titleFallback,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                       )
-                    : ThreadDetailTitle(fallback: titleFallback),
+                    : BlocBuilder<ItemActionsCubit, ItemActionsState>(
+                        buildWhen: (p, c) => p.item != c.item,
+                        builder: (context, state) => ThreadDetailTitle(
+                          fallback: titleFallback,
+                          item: state.item,
+                        ),
+                      ),
                 actions: item == null
                     ? null
                     : const [ThreadDetailOverflowAction()],

--- a/packages/client/lib/features/beacon_threads/ui/widget/thread_detail.dart
+++ b/packages/client/lib/features/beacon_threads/ui/widget/thread_detail.dart
@@ -2,12 +2,17 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:tentura/design_system/tentura_design_system.dart';
+import 'package:tentura/domain/entity/beacon.dart';
+import 'package:tentura/domain/entity/beacon_participant.dart';
 import 'package:tentura/domain/entity/coordination_item.dart';
+import 'package:tentura/domain/entity/profile.dart';
 import 'package:tentura/features/beacon_threads/domain/entity/request_thread.dart';
 import 'package:tentura/features/beacon_threads/ui/bloc/room_cubit.dart';
+import 'package:tentura/features/beacon_threads/ui/bloc/thread_host_cubit.dart';
 import 'package:tentura/features/beacon_threads/ui/widget/beacon_room_body.dart';
 import 'package:tentura/features/beacon_threads/ui/widget/thread_host.dart';
 import 'package:tentura/ui/l10n/l10n.dart';
+import 'package:tentura/ui/widget/beacon_involved_people_face_pile.dart';
 import 'package:tentura/ui/widget/coordination_item_presenter.dart';
 import 'package:tentura/ui/widget/coordination_item_card_chrome.dart';
 
@@ -32,7 +37,20 @@ String threadTitleFallback(L10n l10n, RequestThread thread) {
   };
 }
 
-/// Thread body (optional semantic header + messages) without a [Scaffold].
+String threadGeneralAppBarTitle(L10n l10n, Beacon beacon) =>
+    beacon.title.isEmpty ? l10n.beaconViewTitle : beacon.title;
+
+String _threadItemKindLabel(L10n l10n, CoordinationItem item) =>
+    switch (item.kind) {
+      CoordinationItemKind.blocker => l10n.coordinationBlockerCardLabel,
+      CoordinationItemKind.ask => l10n.coordinationAskCardLabel,
+      CoordinationItemKind.promise => l10n.coordinationPromiseCardLabel,
+      CoordinationItemKind.plan => item.isPlanStep
+          ? l10n.coordinationPlanStepCardLabel
+          : l10n.coordinationPlanCardLabel,
+    };
+
+/// Thread body (messages) without a [Scaffold].
 class ThreadDetail extends StatelessWidget {
   const ThreadDetail({
     required this.thread,
@@ -49,14 +67,12 @@ class ThreadDetail extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final item = thread.item;
     return ThreadHost(
       child: TenturaChatColumn(
         child: Column(
+          key: ValueKey(thread.threadId),
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            if (item != null)
-              _ThreadDetailSemanticHeader(item: item),
             Expanded(
               child: BeaconRoomBody(
                 beaconAuthorId: beaconAuthorId,
@@ -116,8 +132,12 @@ class ThreadDetailColumnChrome extends StatelessWidget {
                 ),
               ),
               Expanded(
-                child: ThreadDetailTitle(
-                  fallback: titleFallback,
+                child: BlocBuilder<ItemActionsCubit, ItemActionsState>(
+                  buildWhen: (p, c) => p.item != c.item,
+                  builder: (context, state) => ThreadDetailTitle(
+                    fallback: titleFallback,
+                    item: state.item,
+                  ),
                 ),
               ),
               const ThreadDetailOverflowAction(),
@@ -129,20 +149,185 @@ class ThreadDetailColumnChrome extends StatelessWidget {
   }
 }
 
-class ThreadDetailTitle extends StatelessWidget {
-  const ThreadDetailTitle({required this.fallback, super.key});
+/// Compact two-line app-bar title shared by General and semantic threads.
+class ThreadDetailAppBarTitle extends StatelessWidget {
+  const ThreadDetailAppBarTitle({
+    required this.title,
+    required this.subtitle,
+    super.key,
+  });
 
-  final String fallback;
+  final String title;
+  final Widget subtitle;
 
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<ItemActionsCubit, ItemActionsState>(
-      buildWhen: (p, c) => p.item != c.item,
-      builder: (context, state) => Text(
-        state.item.title.isEmpty ? fallback : state.item.title,
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
+    final scheme = Theme.of(context).colorScheme;
+    return Row(
+      children: [
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TenturaText.titleSmall(scheme.onSurface),
+              ),
+              subtitle,
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Two-row app-bar title for General: request title plus involved-people pile.
+class ThreadDetailGeneralTitle extends StatelessWidget {
+  const ThreadDetailGeneralTitle({
+    required this.title,
+    required this.beacon,
+    required this.involvedProfiles,
+    required this.currentUserId,
+    super.key,
+  });
+
+  final String title;
+  final Beacon beacon;
+  final List<Profile> involvedProfiles;
+  final String currentUserId;
+
+  @override
+  Widget build(BuildContext context) {
+    return ThreadDetailAppBarTitle(
+      title: title,
+      subtitle: ExcludeSemantics(
+        child: BeaconInvolvedPeopleFacePile(
+          beacon: beacon,
+          involvedProfiles: involvedProfiles,
+          currentUserId: currentUserId,
+        ),
       ),
+    );
+  }
+}
+
+/// Two-row app-bar title for a non-general thread: item title plus icon/meta.
+class ThreadDetailTitle extends StatelessWidget {
+  const ThreadDetailTitle({
+    required this.fallback,
+    required this.item,
+    super.key,
+  });
+
+  final String fallback;
+  final CoordinationItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = L10n.of(context)!;
+    final title = item.title.trim().isEmpty ? fallback : item.title.trim();
+    final tt = context.tt;
+    final statusColor = coordinationItemColor(tt, item.kind, item.status);
+    final kindLabel = _threadItemKindLabel(l10n, item);
+    final statusLabel = coordinationItemStatusLabel(l10n, item.status);
+    final headerIcon = coordinationCompoundStatusIcon(
+      kind: item.kind,
+      status: item.status,
+      isPlanStep: item.isPlanStep,
+      tt: tt,
+      size: tt.iconSize,
+    );
+
+    return Semantics(
+      header: true,
+      label: '$title. $kindLabel. $statusLabel',
+      child: ExcludeSemantics(
+        child: ThreadDetailAppBarTitle(
+          title: title,
+          subtitle: _ThreadDetailTitleMetaRow(
+            item: item,
+            headerIcon: headerIcon,
+            kindLabel: kindLabel,
+            statusLabel: statusLabel,
+            statusColor: statusColor,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ThreadDetailTitleMetaRow extends StatelessWidget {
+  const _ThreadDetailTitleMetaRow({
+    required this.item,
+    required this.headerIcon,
+    required this.kindLabel,
+    required this.statusLabel,
+    required this.statusColor,
+  });
+
+  final CoordinationItem item;
+  final Widget headerIcon;
+  final String kindLabel;
+  final String statusLabel;
+  final Color statusColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final tt = context.tt;
+    final metaStyle = theme.textTheme.labelSmall?.copyWith(color: statusColor);
+    final roomCubit = context.read<ThreadHostCubit>().roomCubit;
+
+    Widget row(List<BeaconParticipant> participants) {
+      final avatarTrail = item.kind.hasDirectedParties
+          ? coordinationDirectedAvatarTrailForItem(
+              creatorId: item.creatorId,
+              targetPersonId: item.targetPersonId,
+              participants: participants,
+              avatarSize: tt.avatarTinySize,
+            )
+          : null;
+      return Row(
+        children: [
+          if (avatarTrail != null) ...[
+            avatarTrail,
+            SizedBox(width: tt.rowGap),
+          ],
+          headerIcon,
+          SizedBox(width: tt.iconTextGap),
+          Flexible(
+            child: Text(
+              kindLabel,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: metaStyle,
+            ),
+          ),
+          SizedBox(width: tt.rowGap),
+          Flexible(
+            child: Text(
+              statusLabel,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: metaStyle,
+            ),
+          ),
+        ],
+      );
+    }
+
+    if (roomCubit == null) {
+      return row(const []);
+    }
+    return BlocBuilder<RoomCubit, RoomState>(
+      bloc: roomCubit,
+      buildWhen: (p, c) => p.participants != c.participants,
+      builder: (context, roomState) => row(roomState.participants),
     );
   }
 }
@@ -157,110 +342,6 @@ class ThreadDetailOverflowAction extends StatelessWidget {
       builder: (context, state) => CoordinationItemDiscussionOverflowMenu(
         item: state.item,
         isLoading: state.isLoading,
-      ),
-    );
-  }
-}
-
-class _ThreadDetailSemanticHeader extends StatelessWidget {
-  const _ThreadDetailSemanticHeader({required this.item});
-
-  final CoordinationItem item;
-
-  @override
-  Widget build(BuildContext context) {
-    final l10n = L10n.of(context)!;
-    final theme = Theme.of(context);
-    final preview = item.title.trim();
-    if (preview.isEmpty) {
-      return const SizedBox.shrink();
-    }
-
-    final tt = context.tt;
-    final statusColor = coordinationItemColor(tt, item.kind, item.status);
-    final kindLabel = switch (item.kind) {
-      CoordinationItemKind.blocker => l10n.coordinationBlockerCardLabel,
-      CoordinationItemKind.ask => l10n.coordinationAskCardLabel,
-      CoordinationItemKind.promise => l10n.coordinationPromiseCardLabel,
-      CoordinationItemKind.plan =>
-        item.isPlanStep
-            ? l10n.coordinationPlanStepCardLabel
-            : l10n.coordinationPlanCardLabel,
-    };
-    final headerIcon = coordinationCompoundStatusIcon(
-      kind: item.kind,
-      status: item.status,
-      isPlanStep: item.isPlanStep,
-      tt: tt,
-    );
-
-    return Material(
-      color: statusColor.withValues(alpha: 0.06),
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          border: Border(
-            bottom: BorderSide(
-              color: statusColor.withValues(alpha: 0.2),
-            ),
-          ),
-        ),
-        child: ExpansionTile(
-          leading: Container(width: 3, color: statusColor),
-          title: Text(
-            preview,
-            style: theme.textTheme.bodySmall,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-          ),
-          subtitle: BlocBuilder<RoomCubit, RoomState>(
-            buildWhen: (p, c) => p.participants != c.participants,
-            builder: (context, roomState) {
-              final avatarTrail = item.kind.hasDirectedParties
-                  ? coordinationDirectedAvatarTrailForItem(
-                      creatorId: item.creatorId,
-                      targetPersonId: item.targetPersonId,
-                      participants: roomState.participants,
-                    )
-                  : null;
-              return Row(
-                children: [
-                  if (avatarTrail != null) ...[
-                    avatarTrail,
-                    SizedBox(width: tt.rowGap),
-                  ],
-                  headerIcon,
-                  SizedBox(width: tt.iconTextGap),
-                  Text(
-                    kindLabel,
-                    style: theme.textTheme.labelSmall?.copyWith(
-                      color: statusColor,
-                    ),
-                  ),
-                  SizedBox(width: tt.rowGap),
-                  Text(
-                    coordinationItemStatusLabel(l10n, item.status),
-                    style: theme.textTheme.labelSmall?.copyWith(
-                      color: statusColor,
-                    ),
-                  ),
-                ],
-              );
-            },
-          ),
-          children: [
-            Padding(
-              padding: EdgeInsets.zero.copyWith(
-                left: tt.screenHPadding,
-                right: tt.screenHPadding,
-                bottom: tt.cardGap,
-              ),
-              child: Text(
-                preview,
-                style: theme.textTheme.bodySmall,
-              ),
-            ),
-          ],
-        ),
       ),
     );
   }

--- a/packages/client/lib/features/beacon_threads/ui/widget/threads_list.dart
+++ b/packages/client/lib/features/beacon_threads/ui/widget/threads_list.dart
@@ -7,7 +7,6 @@ import 'package:flutter/material.dart';
 import 'package:tentura/design_system/tentura_design_system.dart';
 import 'package:tentura/domain/entity/beacon_participant.dart';
 import 'package:tentura/domain/entity/coordination_item.dart';
-import 'package:tentura/domain/entity/profile.dart';
 import 'package:tentura/features/beacon_threads/domain/entity/request_thread.dart';
 import 'package:tentura/features/beacon_threads/ui/bloc/threads_cubit.dart';
 import 'package:tentura/features/beacon_threads/ui/bloc/threads_state.dart';
@@ -37,11 +36,6 @@ BeaconParticipant? _participantForUser(
   }
   return null;
 }
-
-List<Profile> _activeHelpOfferUsers(BeaconViewState state) => [
-  for (final offer in state.helpOffers)
-    if (!offer.isWithdrawn) offer.user,
-];
 
 List<RequestThread> _myDraftThreads(ThreadsState threadsState, String myUserId) =>
     threadsState.drafts
@@ -287,7 +281,7 @@ class ThreadsList extends StatelessWidget {
                     isSelected: selectedThreadId == general.threadId,
                     onOpenThread: onOpenThread,
                     generalBeacon: beaconState.beacon,
-                    generalInvolvedProfiles: _activeHelpOfferUsers(beaconState),
+                    generalInvolvedProfiles: beaconState.activeHelpOfferUsers,
                     onGeneralFacePileTap: onSwitchToPeopleTab,
                   ),
                 ),

--- a/packages/client/lib/features/beacon_view/ui/bloc/beacon_view_state.dart
+++ b/packages/client/lib/features/beacon_view/ui/bloc/beacon_view_state.dart
@@ -346,6 +346,12 @@ abstract class BeaconViewState extends StateBase with _$BeaconViewState {
       myActiveHelpOffer?.coordinationResponse ==
       CoordinationResponseType.notSuitable;
 
+  /// Active (non-withdrawn) help-offerers on the General face pile.
+  List<Profile> get activeHelpOfferUsers => [
+        for (final offer in helpOffers)
+          if (!offer.isWithdrawn) offer.user,
+      ];
+
   /// Room access-unavailable banner applies unless the viewer is waiting on
   /// the author after offering help (Items tab shows waiting copy instead).
   bool get showsRoomAccessUnavailableBanner =>

--- a/packages/client/lib/features/beacon_view/ui/screen/beacon_view_screen.dart
+++ b/packages/client/lib/features/beacon_view/ui/screen/beacon_view_screen.dart
@@ -627,6 +627,49 @@ class _BeaconViewScreenState extends State<BeaconViewScreen> {
     );
   }
 
+  Widget _splitThreadPaneAppBar({
+    required ThreadsState threadsState,
+    required ThreadHostState hostState,
+    required BeaconViewState beaconState,
+    required L10n l10n,
+    required Widget overflow,
+  }) {
+    final thread = _selectedThread(threadsState, hostState);
+    if (thread == null) {
+      return Align(
+        alignment: Alignment.centerRight,
+        child: overflow,
+      );
+    }
+
+    final Widget title;
+    if (thread.isGeneral) {
+      title = ThreadDetailGeneralTitle(
+        title: threadGeneralAppBarTitle(l10n, beaconState.beacon),
+        beacon: beaconState.beacon,
+        involvedProfiles: beaconState.activeHelpOfferUsers,
+        currentUserId: beaconState.myProfile.id,
+      );
+    } else if (thread.item != null) {
+      title = ThreadDetailTitle(
+        fallback: threadTitleFallback(l10n, thread),
+        item: thread.item!,
+      );
+    } else {
+      return Align(
+        alignment: Alignment.centerRight,
+        child: overflow,
+      );
+    }
+
+    return Row(
+      children: [
+        Expanded(child: title),
+        overflow,
+      ],
+    );
+  }
+
   Widget _buildExpandedSplitBody({
     required BeaconViewState beaconState,
     required BeaconViewCubit beaconViewCubit,
@@ -1091,9 +1134,12 @@ class _BeaconViewScreenState extends State<BeaconViewScreen> {
                                         const SizedBox(width: handleWidth),
                                         SizedBox(
                                           width: threadPaneWidth,
-                                          child: Align(
-                                            alignment: Alignment.centerRight,
-                                            child: overflow,
+                                          child: _splitThreadPaneAppBar(
+                                            threadsState: threadsState,
+                                            hostState: hostState,
+                                            beaconState: state,
+                                            l10n: l10n,
+                                            overflow: overflow,
                                           ),
                                         ),
                                       ],

--- a/packages/client/pubspec.yaml
+++ b/packages/client/pubspec.yaml
@@ -2,7 +2,7 @@ name: tentura
 description: 'Social network for communities'
 publish_to: 'none'
 
-version: 6.3.4
+version: 6.3.5
 
 environment:
   sdk: ^3.12.0

--- a/packages/client/test/features/beacon_threads/thread_detail_test.dart
+++ b/packages/client/test/features/beacon_threads/thread_detail_test.dart
@@ -32,6 +32,7 @@ import 'package:tentura/ui/bloc/state_base.dart';
 import 'package:tentura/ui/effect/ui_effect_port.dart';
 import 'package:tentura/ui/l10n/l10n.dart';
 import 'package:tentura/ui/test_ids.dart';
+import 'package:tentura/ui/widget/beacon_involved_people_face_pile.dart';
 
 import 'fake_coordination_item_case.dart';
 import 'room_cubit_fakes.dart';
@@ -352,7 +353,9 @@ void main() {
       expect(find.byType(BeaconRoomBody), findsOneWidget);
     });
 
-    testWidgets('semantic thread renders semantic header', (tester) async {
+    testWidgets('semantic thread renders body without pinned header', (
+      tester,
+    ) async {
       final host = _host();
       final thread = _semanticThread('ask-1');
       await host.select(thread);
@@ -396,8 +399,8 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 50));
 
-      expect(find.byType(ExpansionTile), findsOneWidget);
-      expect(find.textContaining('Ask title preview'), findsWidgets);
+      expect(find.byType(ExpansionTile), findsNothing);
+      expect(find.byType(BeaconRoomBody), findsOneWidget);
     });
   });
 
@@ -422,11 +425,17 @@ void main() {
         router: router,
       );
 
+      expect(find.byType(ThreadDetailGeneralTitle), findsOneWidget);
       expect(find.text('Request title'), findsOneWidget);
+      expect(find.byType(BeaconInvolvedPeopleFacePile), findsOneWidget);
       expect(
         find.byKey(TestIds.key(TestIds.roomMessageInput)),
         findsOneWidget,
       );
+
+      await tester.tap(find.text('Request title'));
+      await tester.pump();
+      expect(tester.takeException(), isNull);
     });
 
     testWidgets('ask thread AppBar title and overflow find ItemActionsCubit', (
@@ -453,7 +462,10 @@ void main() {
       expect(tester.takeException(), isNull);
       expect(find.byType(ThreadDetailTitle), findsOneWidget);
       expect(find.byType(ThreadDetailOverflowAction), findsOneWidget);
-      expect(find.text('Ask title preview'), findsWidgets);
+      expect(find.byType(ExpansionTile), findsNothing);
+      expect(find.text('Ask title preview'), findsOneWidget);
+      expect(find.text('Ask'), findsOneWidget);
+      expect(find.text('Open'), findsOneWidget);
     });
 
     testWidgets('close awaits host clear before route pop completes', (

--- a/packages/client/web/index.html
+++ b/packages/client/web/index.html
@@ -129,7 +129,7 @@
     }
   </script>
 
-  <script src="flutter_bootstrap.js?v=6.3.4" async=""></script>
+  <script src="flutter_bootstrap.js?v=6.3.5" async=""></script>
 
   <script>
     if ('serviceWorker' in navigator) {


### PR DESCRIPTION
## Summary
- Ask / promise / blocker / plan threads no longer pin an info strip under the app bar. Title, avatars, kind, and status live in the top bar.
- General uses the same two-line chrome: request title plus the topics-tab involved-people face pile.
- Face-pile semantics are excluded in the app bar so Flutter web hit-testing stays valid.

Client version **6.3.5** (cache-buster synced).

## Test plan
- [ ] Compact: open an ask thread — top bar shows item title + avatars/status; no ExpansionTile header under the bar
- [ ] Compact: open General — top bar shows request title + mini-avatar strip
- [ ] Expanded split: right pane top bar matches the same two-line chrome
- [ ] Web: tap the General top-bar title without `Cannot hit test a render box that has never been laid out`


Made with [Cursor](https://cursor.com)